### PR TITLE
uidをローカルに保存する

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -35,6 +35,13 @@ target 'Runner' do
 end
 
 post_install do |installer|
+  installer.generated_projects.each do |project|
+    project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+      end
+   end
+  end
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
   end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -767,9 +767,9 @@ DEPENDENCIES:
   - firebase_storage (from `.symlinks/plugins/firebase_storage/ios`)
   - Flutter (from `Flutter`)
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
   - qr_code_scanner (from `.symlinks/plugins/qr_code_scanner/ios`)
-  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/ios`)
 
 SPEC REPOS:
   trunk:
@@ -809,11 +809,11 @@ EXTERNAL SOURCES:
   fluttertoast:
     :path: ".symlinks/plugins/fluttertoast/ios"
   path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/darwin"
+    :path: ".symlinks/plugins/path_provider_foundation/ios"
   qr_code_scanner:
     :path: ".symlinks/plugins/qr_code_scanner/ios"
   shared_preferences_foundation:
-    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+    :path: ".symlinks/plugins/shared_preferences_foundation/ios"
 
 SPEC CHECKSUMS:
   abseil: ebe5b5529fb05d93a8bdb7951607be08b7fa71bc
@@ -847,6 +847,6 @@ SPEC CHECKSUMS:
   shared_preferences_foundation: 297b3ebca31b34ec92be11acd7fb0ba932c822ca
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
-PODFILE CHECKSUM: 7368163408c647b7eb699d0d788ba6718e18fb8d
+PODFILE CHECKSUM: 8bd16479139fc90c6cfb7407d156bd88e30f2de3
 
 COCOAPODS: 1.12.1

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,7 @@
 import 'package:device_preview/device_preview.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:wru/data/model/result/result.dart';
+import 'package:wru/data/provider/uid_provider.dart';
 import 'package:wru/ui/routes/app_route.gr.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -15,20 +17,26 @@ class MyApp extends HookConsumerWidget {
     final theme = ref.watch(appThemeProvider);
     final themeMode = ref.watch(appThemeModeProvider);
     final appRouter = useMemoized(() => AppRouter());
+    final fetchUid = ref.watch(fetchUidProvider);
 
-    return Sizer(
-      builder: (context, orientation, deviceType) => MaterialApp.router(
-        debugShowCheckedModeBanner: false,
-        useInheritedMediaQuery: true,
-        theme: theme.data,
-        darkTheme: AppTheme.dark().data,
-        themeMode: themeMode,
-        locale: DevicePreview.locale(context),
-        localizationsDelegates: L10n.localizationsDelegates,
-        supportedLocales: L10n.supportedLocales,
-        routeInformationParser: appRouter.defaultRouteParser(),
-        routerDelegate: appRouter.delegate(),
-      ),
-    );
+    return fetchUid.when(
+        data: (data) {
+          return Sizer(
+            builder: (context, orientation, deviceType) => MaterialApp.router(
+              debugShowCheckedModeBanner: false,
+              useInheritedMediaQuery: true,
+              theme: theme.data,
+              darkTheme: AppTheme.dark().data,
+              themeMode: themeMode,
+              locale: DevicePreview.locale(context),
+              localizationsDelegates: L10n.localizationsDelegates,
+              supportedLocales: L10n.supportedLocales,
+              routeInformationParser: appRouter.defaultRouteParser(),
+              routerDelegate: appRouter.delegate(),
+            ),
+          );
+        },
+        error: (error, stackTrace) => Text(error.toString()),
+        loading: () => const CircularProgressIndicator());
   }
 }

--- a/lib/data/provider/uid_provider.dart
+++ b/lib/data/provider/uid_provider.dart
@@ -1,6 +1,31 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final initUidProvider = StateNotifierProvider((ref) => InitUidNotifier(ref));
+
+final fetchUidProvider = FutureProvider((ref) async {
+  const key = "uid_key";
+  SharedPreferences pref = await SharedPreferences.getInstance();
+  //uidProviderに管理してもらう
+  final uid = pref.getString(key) ?? '';
+  ref.watch(uidProvider.notifier).state = uid;
+  return uid;
+});
+
+class InitUidNotifier extends StateNotifier {
+  InitUidNotifier(this._ref) : super('');
+  final Ref _ref;
+  final key = "uid_key";
+
+  //uidを保存する
+  Future<void> saveUid(String uid) async {
+    //uidProviderに管理してもらう
+    _ref.watch(uidProvider.notifier).state = uid;
+    SharedPreferences pref = await SharedPreferences.getInstance();
+    pref.setString(key, uid);
+    print(_ref.watch(uidProvider));
+  }
+}
 
 //uidのプロバイダー
-//#TODO
-final uidProvider =
-    StateProvider<String>((ref) => 'EKwJmH5SzfdmEmSxcTeIKcBkLW42');
+final uidProvider = StateProvider((_) => '');

--- a/lib/ui/signIn/sign_in_view_model.dart
+++ b/lib/ui/signIn/sign_in_view_model.dart
@@ -41,18 +41,17 @@ class SignInViewModel extends StateNotifier<AsyncValue<SignInState>> {
 
   Future<void> signIn() async {
     SignInState currentState = state.value!;
-    final uidNotifier = _ref.read(uidProvider.notifier);
+    final initUidNotifier = _ref.read(initUidProvider.notifier);
     final errorNotifier = _ref.read(signInErrorProvider.notifier);
     //取得したAppUser
     final result =
         await _repository.signIn(currentState.email, currentState.password);
     result.when(
-      success: (appUser) {
+      success: (appUser) async {
         if (appUser != null) {
           //ログイン可能な場合の処理
           //uidをプロバイダーでかんりする
-          uidNotifier.state = appUser.uid;
-          print(appUser.toString());
+          await initUidNotifier.saveUid(appUser.uid);
         } else {
           state = AsyncValue.data(
             SignInState(

--- a/lib/ui/signUp/sign_up_view_model.dart
+++ b/lib/ui/signUp/sign_up_view_model.dart
@@ -41,17 +41,17 @@ class SignUpViewModel extends StateNotifier<AsyncValue<SignUpState>> {
 
   Future<void> singUp() async {
     SignUpState currentState = state.value!;
-    final uidNotifier = _ref.read(uidProvider.notifier);
+    final initUidNotifier = _ref.read(initUidProvider.notifier);
     final errorNotifier = _ref.read(signUpErrorProvider.notifier);
     //取得したAppUser
     final result =
         await _repository.signUp(currentState.email, currentState.password);
     result.when(
-      success: (appUser) {
+      success: (appUser) async {
         if (appUser != null) {
           //ログイン可能な場合の処理
-          //uidをプロバイダーでかんりする
-          uidNotifier.state = appUser.uid;
+          //uidをプロバイダーでかんりする ローカルに保存
+          await initUidNotifier.saveUid(appUser.uid);
           print(appUser.toString());
         } else {
           state = AsyncValue.data(

--- a/lib/ui/tabs/home/home_page.dart
+++ b/lib/ui/tabs/home/home_page.dart
@@ -45,7 +45,9 @@ class HomePage extends HookConsumerWidget {
                     const SizedBox(height: 12),
                     infoList.when(
                       data: (info) {
-                        if (info.isNotEmpty && info[0] != '') {
+                        if (info.isNotEmpty &&
+                            info[0] != '' &&
+                            info[0] != null) {
                           print(info);
                           return FittedBox(
                               fit: BoxFit.fitWidth,
@@ -69,7 +71,9 @@ class HomePage extends HookConsumerWidget {
                     const SizedBox(height: 0),
                     infoList.when(
                       data: (info) {
-                        if (info.isNotEmpty && info[1] != '') {
+                        if (info.isNotEmpty &&
+                            info[1] != '' &&
+                            info[1] != null) {
                           return FittedBox(
                               fit: BoxFit.fitWidth,
                               child: Text(

--- a/lib/ui/tabs/home/home_view_model.dart
+++ b/lib/ui/tabs/home/home_view_model.dart
@@ -39,7 +39,8 @@ class homeImgUrlNotifier extends StateNotifier<String?> {
     }
     if (myMap == null || myMap['imgUrl'] == null || myMap['imgUrl'].isEmpty) {
       state = null;
+      return;
     }
-    state = myMap!['imgUrl'];
+    state = myMap['imgUrl'];
   }
 }


### PR DESCRIPTION
#59 
## 実装内容

- uidをproviderで管理する
- signIn,signUp時にローカルに保存すると同時にプロバイダーで管理する
- app.dartで毎回uidをローカルから取得する